### PR TITLE
numpy tricks

### DIFF
--- a/napari/utils/aabb.py
+++ b/napari/utils/aabb.py
@@ -42,20 +42,18 @@ def construct_bvh(triangles):
     if len(triangles) == 0:
         return None
 
-    all_vertices = np.concatenate(triangles)
     bounding_box = BoundingBox(
-        np.min(all_vertices, axis=0), np.max(all_vertices, axis=0), triangles
+        np.min(triangles, axis=(0, 1)),
+        np.max(triangles, axis=(0, 1)),
+        triangles,
     )
 
     # print("diff in  coords: ", bounding_box.max_coords - bounding_box.min_coords)
     split_axis = np.argmax(bounding_box.max_coords - bounding_box.min_coords)
     # # TODO: Should be optimized to use SAH partitioning technique.
     # # Tradeoff - might take longer time to build the tree but possibly faster querying when checking for intersection.
-    # split_axis = 0
-    sorted_triangles = np.array(
-        sorted(triangles, key=lambda triangle: triangle[:, split_axis].mean())
-    )
-    # sorted_triangles = triangles
+    sort_indices = np.argsort(triangles[:, :, split_axis].mean(axis=-1))
+    sorted_triangles = triangles[sort_indices]
 
     if len(sorted_triangles) <= min_primitives_per_node:
         return BVHNode(None, None, bounding_box)


### PR DESCRIPTION
Hi Aakash - here are some numpy tricks that I think greatly accelerate your BVH construction. I'm pretty sure the behavior is unchanged but appreciate if you can verify that for me.

I used `cProfile` to identify the hot spots in your function. Here's the initial result:
```
----------BVH Construction----------
         108504975 function calls (108502929 primitive calls) in 50.963 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2047    0.001    0.000    0.305    0.000 <__array_function__ internals>:177(amax)
     2047    0.002    0.000    0.316    0.000 <__array_function__ internals>:177(amin)
     2047    0.001    0.000    0.007    0.000 <__array_function__ internals>:177(argmax)
     2047    0.002    0.000    2.768    0.001 <__array_function__ internals>:177(concatenate)
  9857848   20.809    0.000   37.490    0.000 _methods.py:164(_mean)
  9857848    6.345    0.000    6.964    0.000 _methods.py:67(_count_reduce_items)
     2047    0.001    0.000    0.001    0.000 aabb.py:16(__init__)
   2047/1    0.400    0.000   50.963   50.963 aabb.py:41(construct_bvh)
  9857848    2.756    0.000   41.808    0.000 aabb.py:56(<lambda>)
     2047    0.001    0.000    0.001    0.000 aabb.py:9(__init__)
       13    0.000    0.000    0.000    0.000 base_transform.py:192(__del__)
        1    0.000    0.000    0.000    0.000 cProfile.py:40(print_stats)
        1    0.000    0.000    0.000    0.000 cProfile.py:50(create_stats)
        4    0.000    0.000    0.000    0.000 chain.py:241(__del__)
       22    0.000    0.000    0.000    0.000 event.py:372(disconnect)
        5    0.000    0.000    0.000    0.000 event.py:388(_normalize_cb)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:1149(_argmax_dispatcher)
     2047    0.002    0.000    0.005    0.000 fromnumeric.py:1153(argmax)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:2698(_amax_dispatcher)
     2047    0.001    0.000    0.303    0.000 fromnumeric.py:2703(amax)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:2824(_amin_dispatcher)
     2047    0.002    0.000    0.313    0.000 fromnumeric.py:2829(amin)
     2047    0.001    0.000    0.003    0.000 fromnumeric.py:51(_wrapfunc)
     4094    0.005    0.000    0.612    0.000 fromnumeric.py:69(_wrapreduction)
     4094    0.002    0.000    0.002    0.000 fromnumeric.py:70(<dictcomp>)
        5    0.000    0.000    0.000    0.000 inspect.py:199(ismethod)
     2047    0.000    0.000    0.000    0.000 multiarray.py:152(concatenate)
        1    0.000    0.000    0.000    0.000 pstats.py:107(__init__)
        1    0.000    0.000    0.000    0.000 pstats.py:117(init)
        1    0.000    0.000    0.000    0.000 pstats.py:136(load_stats)
     2047    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
  9857849    0.706    0.000    0.706    0.000 {built-in method builtins.hasattr}
  9857864    0.648    0.000    0.648    0.000 {built-in method builtins.isinstance}
 19715696    0.939    0.000    0.939    0.000 {built-in method builtins.issubclass}
     5118    0.001    0.000    0.001    0.000 {built-in method builtins.len}
     2047    3.088    0.002   44.896    0.022 {built-in method builtins.sorted}
     2047    2.268    0.001    2.268    0.001 {built-in method numpy.array}
  9857848    0.465    0.000    0.465    0.000 {built-in method numpy.asanyarray}
     8188    2.768    0.000    3.389    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
  9857848    0.618    0.000    0.618    0.000 {built-in method numpy.core._multiarray_umath.normalize_axis_index}
     2047    0.002    0.000    0.002    0.000 {method 'argmax' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     4094    0.000    0.000    0.000    0.000 {method 'items' of 'dict' objects}
  9857848    1.562    0.000   39.052    0.000 {method 'mean' of 'numpy.ndarray' objects}
  9861942    7.564    0.000    7.564    0.000 {method 'reduce' of 'numpy.ufunc' objects}
```

What stood out to me here were these lines - this is where you are sorting.
```
  9857848   20.809    0.000   37.490    0.000 _methods.py:164(_mean)`
  9857848    2.756    0.000   41.808    0.000 aabb.py:56(<lambda>)
```
This suggests it's not actually the sort that was slow, it's the key function.

Well, we can use numpy to calculate the mean we're interested in all at once, and then sort based on that.

This is the result of profiling with just that change:
```
----------BVH Construction----------
         121805 function calls (119759 primitive calls) in 3.998 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2047    0.001    0.000    0.298    0.000 <__array_function__ internals>:177(amax)
     2047    0.001    0.000    0.301    0.000 <__array_function__ internals>:177(amin)
     2047    0.001    0.000    0.004    0.000 <__array_function__ internals>:177(argmax)
     2047    0.001    0.000    0.528    0.000 <__array_function__ internals>:177(argsort)
     2047    0.001    0.000    2.623    0.001 <__array_function__ internals>:177(concatenate)
     2047    0.008    0.000    0.077    0.000 _methods.py:164(_mean)
     2047    0.002    0.000    0.002    0.000 _methods.py:67(_count_reduce_items)
     4094    0.001    0.000    0.002    0.000 _ufunc_config.py:452(_no_nep50_warning)
     2047    0.000    0.000    0.000    0.000 aabb.py:16(__init__)
   2047/1    0.164    0.000    3.997    3.997 aabb.py:41(construct_bvh)
     2047    0.000    0.000    0.000    0.000 aabb.py:9(__init__)
        1    0.000    0.000    0.000    0.000 cProfile.py:40(print_stats)
        1    0.000    0.000    0.000    0.000 cProfile.py:50(create_stats)
     2047    0.001    0.000    0.002    0.000 contextlib.py:102(__init__)
     2047    0.001    0.000    0.003    0.000 contextlib.py:130(__enter__)
     2047    0.001    0.000    0.002    0.000 contextlib.py:139(__exit__)
     2047    0.001    0.000    0.002    0.000 contextlib.py:279(helper)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:1034(_argsort_dispatcher)
     2047    0.001    0.000    0.526    0.000 fromnumeric.py:1038(argsort)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:1149(_argmax_dispatcher)
     2047    0.001    0.000    0.003    0.000 fromnumeric.py:1153(argmax)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:2698(_amax_dispatcher)
     2047    0.001    0.000    0.297    0.000 fromnumeric.py:2703(amax)
     2047    0.000    0.000    0.000    0.000 fromnumeric.py:2824(_amin_dispatcher)
     2047    0.001    0.000    0.299    0.000 fromnumeric.py:2829(amin)
     4094    0.001    0.000    0.527    0.000 fromnumeric.py:51(_wrapfunc)
     4094    0.003    0.000    0.594    0.000 fromnumeric.py:69(_wrapreduction)
     4094    0.001    0.000    0.001    0.000 fromnumeric.py:70(<dictcomp>)
     2047    0.000    0.000    0.000    0.000 multiarray.py:152(concatenate)
        1    0.000    0.000    0.000    0.000 pstats.py:107(__init__)
        1    0.000    0.000    0.000    0.000 pstats.py:117(init)
        1    0.000    0.000    0.000    0.000 pstats.py:136(load_stats)
     6141    0.001    0.000    0.001    0.000 {built-in method builtins.getattr}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
     4095    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
     4094    0.000    0.000    0.000    0.000 {built-in method builtins.issubclass}
     5118    0.000    0.000    0.000    0.000 {built-in method builtins.len}
     4094    0.001    0.000    0.003    0.000 {built-in method builtins.next}
     2047    0.000    0.000    0.000    0.000 {built-in method numpy.asanyarray}
    10235    2.624    0.000    3.749    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
     2047    0.000    0.000    0.000    0.000 {built-in method numpy.core._multiarray_umath.normalize_axis_index}
     2047    0.001    0.000    0.001    0.000 {method 'argmax' of 'numpy.ndarray' objects}
     2047    0.525    0.000    0.525    0.000 {method 'argsort' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     4094    0.000    0.000    0.000    0.000 {method 'items' of 'dict' objects}
     2047    0.001    0.000    0.078    0.000 {method 'mean' of 'numpy.ndarray' objects}
     6141    0.650    0.000    0.650    0.000 {method 'reduce' of 'numpy.ufunc' objects}
     2047    0.000    0.000    0.000    0.000 {method 'reset' of '_contextvars.ContextVar' objects}
     2047    0.001    0.000    0.001    0.000 {method 'set' of '_contextvars.ContextVar' objects}
```

Now this is the line that caught my eye:
```
     2047    0.001    0.000    2.623    0.001 <__array_function__ internals>:177(concatenate)
```
The reason this is slow is that it's doing a new allocation and copying the values from triangles into it. There are a few ways to avoid this, but `min` and `max` conveniently can operate smartly on multiple axes.
